### PR TITLE
Correct "sunbusrt" typo in filename and header

### DIFF
--- a/user-guide/query-examples-hacks/sunburst-sankey-example.md
+++ b/user-guide/query-examples-hacks/sunburst-sankey-example.md
@@ -2,7 +2,7 @@
 description: Write and investigate user flow and funnel queries in a few moments with this example we use internally in Redash.
 ---
 
-# Funnel Queries (Sankey and Sunbusrt Visualizations)
+# Funnel Queries (Sankey and Sunburst Visualizations)
 
 Sankey and Sunburst visualizations are very good for understanding behavioral flows and sequences.
 


### PR DESCRIPTION
Due to the filename typo the URL for https://redash.io/help/query-examples-hacks/sunbusrt-sankey-example.html would change as well, so I'm not sure of the implications of that, such as needing to set up a redirect.