### PR TITLE
Renamed to "Elasticsearch"

### DIFF
--- a/onpremise/setup/supported-data-sources-options-reqs.md
+++ b/onpremise/setup/supported-data-sources-options-reqs.md
@@ -72,9 +72,9 @@ If one of the listed data source types isn’t available when trying to create a
 
 For information on how to write MongoDB queries, see [_documentation_](https://redash.io/help/queries/querying_mongodb.html).
 
-## ElasticSearch
+## Elasticsearch
 
-For information on how to write ElasticSearch queries, see [_documentation_](https://redash.io/help/queries/querying_elasticsearch.html).
+For information on how to write Elasticsearch queries, see [_documentation_](https://redash.io/help/queries/querying_elasticsearch.html).
 
 ## InfluxDB
 

--- a/user-guide/SUMMARY.md
+++ b/user-guide/SUMMARY.md
@@ -23,7 +23,7 @@
 ## Querying
 * [How to Create a New Query?](queries/query_actions.md#how_to_create_a_query)
 * [How to Write a Query?](queries/writing_queries.md#how_to_write_a_query)
-* [Querying ElasticSearch](queries/querying_elasticsearch.md)
+* [Querying Elasticsearch](queries/querying_elasticsearch.md)
 * [Querying JIRA (JQL)](queries/querying_jira_jql.md)
 * [Querying MongoDB](queries/querying_mongodb.md)
 * [Shortcuts](queries/writing_queries.md#shortcuts)

--- a/user-guide/aboutrd/aboutrd.md
+++ b/user-guide/aboutrd/aboutrd.md
@@ -38,7 +38,7 @@ Redash plays nice with all data sources!
 * Axibase Time Series Database
 * BigQuery
 * Cassandra
-* ElasticSearch
+* Elasticsearch
 * JIRA
 * JSON
 * Google Analytics

--- a/user-guide/queries/querying_elasticsearch.md
+++ b/user-guide/queries/querying_elasticsearch.md
@@ -1,10 +1,10 @@
 ---
-description: Connect ElasticSearch to Redash easily and query, visualize and share it in moments.
+description: Connect Elasticsearch to Redash easily and query, visualize and share it in moments.
 ---
 
-# Querying ElasticSearch
+# Querying Elasticsearch
 
-We support two flavors of ElasticSearch queries, Lucene/string style queries (like Kibana) and the more elaborate JSON based queries. For the first one create a data source of type `Kibana` and for the later create data source of type `ElasticSearch`.
+We support two flavors of Elasticsearch queries, Lucene/string style queries (like Kibana) and the more elaborate JSON based queries. For the first one create a data source of type `Kibana` and for the later create data source of type `Elasticsearch`.
 
 ## String query example:
 
@@ -25,7 +25,7 @@ We support two flavors of ElasticSearch queries, Lucene/string style queries (li
 }
 ```
 
-## Simple query on a logstash ElasticSearch instance:
+## Simple query on a logstash Elasticsearch instance:
 
 * Query the index named “logstash-2015.04.* (in this case its all of April 2015)
 * Filter by type:events AND eventName:UserUpgrade AND channel:selfserve
@@ -44,7 +44,7 @@ We support two flavors of ElasticSearch queries, Lucene/string style queries (li
 }
 ```
 
-## JSON document query on a ElasticSearch instance:
+## JSON document query on a Elasticsearch instance:
 
 * Query the index named “twitter”
 * Filter by user equal “kimchy”

--- a/user-guide/queries/writing_queries.md
+++ b/user-guide/queries/writing_queries.md
@@ -19,7 +19,7 @@ For SQL databases just use the native syntax for that database.
 
 For NoSQL languages Redash has a few nuances:
 
-* [Querying ElasticSearch](querying_elasticsearch.md)
+* [Querying Elasticsearch](querying_elasticsearch.md)
 * [Querying JIRA (JQL)](querying_jira_jql.md)
 * [Querying MongoDB](querying_mongodb.md)
 

--- a/website/_data_sources/elasticsearch.html
+++ b/website/_data_sources/elasticsearch.html
@@ -1,7 +1,7 @@
 ---
-title: Query and Visualize data from ElasticSearch
+title: Query and Visualize data from Elasticsearch
 layout: data_source
-name: ElasticSearch
+name: Elasticsearch
 logo: /assets/images/temp/ElasticSearch2.png
 show_on_homepage: true
 ---

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -7,7 +7,7 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>{{ page.title }} | Redash</title>
     <meta name="description" content="Use Redash to connect to any data source (Redshift, BigQuery, MySQL, PostgreSQL, MongoDB and many others), query, visualize and share your data to make your company data driven.">
-    <meta name="keywords" content="Query, SQL, Visualize, Data, Insights, Dashboard, Alert, Alerts, web based sql client, integration, integrations, Amazong Redshift, BigQuery, PotsgreSQL, MySQL, TreasureData, MS SQL Server, MongoDB, ElasticSearch, Hive, Google Spreadsheets, Impala, InfluxDB, Presto, ScyllaDB, Cassandra, Amazon DynamoDB, Python, Vertica, Graphite, Stitch, URL">
+    <meta name="keywords" content="Query, SQL, Visualize, Data, Insights, Dashboard, Alert, Alerts, web based sql client, integration, integrations, Amazong Redshift, BigQuery, PotsgreSQL, MySQL, TreasureData, MS SQL Server, MongoDB, Elasticsearch, Hive, Google Spreadsheets, Impala, InfluxDB, Presto, ScyllaDB, Cassandra, Amazon DynamoDB, Python, Vertica, Graphite, Stitch, URL">
     <meta name="og:image" content="http://redash.io/assets/images/logo.png">
     <meta name="og:logo" content="http://redash.io/assets/images/logo.png">
     <link rel="icon" href="/favicon.ico">


### PR DESCRIPTION
# WHAT IS THIS

Hi, `Elasticsearch` is the correct spelling, NOT `ElasticSearch` and `Elastic Search`.

- https://www.elastic.co/products/elasticsearch

So, I renamed to `Elasticsearch`.
( Please review together -> https://github.com/getredash/redash/pull/2222 :octocat:  )

# TARGET DOCUMENTS

- https://redash.io/help-onpremise/setup/supported-data-sources-options-reqs.html
- http://help.redash.io/article/111-querying-elastic-search
- http://help.redash.io/article/119-supported-data-sources
- And more ❓ 

Please review, thank you 👍 