### PR TITLE
Modify docker-compose usage

### DIFF
--- a/onpremise/dev/docker.md
+++ b/onpremise/dev/docker.md
@@ -77,8 +77,8 @@ If you pulled a new version with new packages or added some yourself, you will n
 rebuild the `server` and `worker` images:
 
 ```bash
-docker-compose rebuild worker
-docker-compose rebuild server
+docker-compose build worker
+docker-compose build server
 ```
 
 ### Running Tests


### PR DESCRIPTION
I found a mistake of usage of docker-compose.

`docker-compose rebuild` doesn't exist. (`docker-compose build` is right.)
https://docs.docker.com/compose/reference/build/
