### PR TITLE
Update docker.md with https based clone url

### DIFF
--- a/website/_kb/open-source/dev-guide/docker.md
+++ b/website/_kb/open-source/dev-guide/docker.md
@@ -19,7 +19,7 @@ which we will run locally.
 First you will need to clone the Git repository:
 
 ```bash
-git clone git@github.com:getredash/redash.git
+git clone https://github.com/getredash/redash.git
 cd redash/
 ```
 


### PR DESCRIPTION
The documentation links to the redash repo via SSH which requires authentication.  I've changed it to use the https link so people without a a github account can reference it.