### PR TITLE
Fix documentation restricted Google Sheets query

### DIFF
--- a/website/_kb/data-sources/querying-a-google-spreadsheet.md
+++ b/website/_kb/data-sources/querying-a-google-spreadsheet.md
@@ -44,8 +44,9 @@ Then the id will be   `1DFuuOMFzNoFQ5EJ2JE2zB79-0uR5zVKvc0EikmvnDgk`.
 
 {% callout warning %}
 If your organization has restrictions on sharing spreadsheets with external
-accounts, it might not work, but worth a try - especially if you created the
-service account with a Google account from the same organization.
+accounts, it will not work. As a workaround, you can add the email address of
+the Google Service Account you're using to the "Who Can Access" list of the 
+Google Sheet you're querying.
 {% endcallout %}
 
 ### Filtering The Data


### PR DESCRIPTION
When querying a restricted access Google Sheets, having the Google Service Account as a part of the organization it's restricted to is not enough to have read access to the sheets. The email address of the Service Account needs to be explicitly added to the "Who Can Access" list to allow it to read.