### PR TITLE
Fix: Top menu link to the forum doesn't work

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -87,7 +87,6 @@ class Header extends React.Component {
               </li>
               <li
                 className={`dropdown ${this.state.dropdownOpen ? 'open' : ''}`}
-                onClick={this.toggleDropdown}
               >
                 <Link
                   to="#"
@@ -97,14 +96,18 @@ class Header extends React.Component {
                   aria-haspopup="true"
                   aria-expanded={this.dropdownOpen}
                 >
-                  Help <span className="caret" />
+                  <span onClick={this.toggleDropdown}>
+                    Help <span className="caret" />
+                  </span>
                 </Link>
                 <ul className="dropdown-menu">
                   <li>
                     <Link to="/help/">Knowledge Base</Link>
                   </li>
                   <li>
-                    <Link to="https://discuss.redash.io/">Forum</Link>
+                    <Link to="https://discuss.redash.io/" target="_blank">
+                      Forum
+                    </Link>
                   </li>
                 </ul>
               </li>


### PR DESCRIPTION
Fixes #185. Simply moved the click to the clickable portion. Works fine.
Also, made the link open in a new window since it's external.