### PR TITLE
Link to MongoDB documentation is broken

### DIFF
--- a/src/pages/kb/data-sources/querying-mongodb.md
+++ b/src/pages/kb/data-sources/querying-mongodb.md
@@ -83,8 +83,7 @@ Aggregation query example:
 
 ### MongoDB Extended JSON Support
 
-We support  [MongoDB Extended JSON](https://docs.mongodb.com/manual/reference
-/mongodb-extended-json/) along with our own extension - `$humanTime`:
+We support  [MongoDB Extended JSON](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) along with our own extension - `$humanTime`:
 
     
     


### PR DESCRIPTION
Links cannot include newline characters.