### PR TITLE
Simplified drawer method

### DIFF
--- a/src/components/hoc/withIframeHook.jsx
+++ b/src/components/hoc/withIframeHook.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+const CLASSNAME = 'drawer'
+
+export default function withIframeHook(Component) {
+  return class extends React.Component {
+    componentDidMount() {
+      if (window.parent !== window) {
+        document.body.classList.add(CLASSNAME)
+      }
+    }
+
+    render() {
+      return <Component {...this.props} />
+    }
+  }
+}

--- a/src/pages/help/index.jsx
+++ b/src/pages/help/index.jsx
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby'
 import Layout from 'components/Layout'
 import Link from 'components/Link'
 import SearchResults from 'components/SearchResults'
-import withIframeHook from 'components/hoc/withIFrameHook'
+import withIframeHook from '../../components/hoc/withIFrameHook'
 import index from 'data/algolia.js'
 
 class HelpPage extends React.Component {

--- a/src/pages/help/index.jsx
+++ b/src/pages/help/index.jsx
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby'
 import Layout from 'components/Layout'
 import Link from 'components/Link'
 import SearchResults from 'components/SearchResults'
-import withIframeHook from '../../components/hoc/withIFrameHook'
+import withIframeHook from 'components/hoc/withIFrameHook'
 import index from 'data/algolia.js'
 
 class HelpPage extends React.Component {

--- a/src/pages/help/index.jsx
+++ b/src/pages/help/index.jsx
@@ -3,7 +3,7 @@ import { graphql } from 'gatsby'
 import Layout from 'components/Layout'
 import Link from 'components/Link'
 import SearchResults from 'components/SearchResults'
-import withIframeHook from 'components/hoc/withIFrameHook'
+import withIframeHook from 'components/hoc/withIframeHook'
 import index from 'data/algolia.js'
 
 class HelpPage extends React.Component {

--- a/src/pages/help/index.jsx
+++ b/src/pages/help/index.jsx
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby'
 import Layout from 'components/Layout'
 import Link from 'components/Link'
 import SearchResults from 'components/SearchResults'
+import withIframeHook from 'components/hoc/withIFrameHook'
 import index from 'data/algolia.js'
 
 class HelpPage extends React.Component {
@@ -140,4 +141,4 @@ export const categoriesQuery = graphql`
   }
 `
 
-export default HelpPage
+export default withIframeHook(HelpPage)

--- a/src/templates/HelpArticle.jsx
+++ b/src/templates/HelpArticle.jsx
@@ -6,7 +6,7 @@ import Link from 'components/Link'
 import SearchResults from 'components/SearchResults'
 import ArticlesList from 'components/ArticlesList'
 import QuickNav from 'components/QuickNav'
-import withIframeHook from '../components/hoc/withIFrameHook'
+import withIframeHook from 'components/hoc/withIFrameHook'
 import index from 'data/algolia.js'
 
 class HelpPageTemplate extends React.Component {

--- a/src/templates/HelpArticle.jsx
+++ b/src/templates/HelpArticle.jsx
@@ -6,7 +6,7 @@ import Link from 'components/Link'
 import SearchResults from 'components/SearchResults'
 import ArticlesList from 'components/ArticlesList'
 import QuickNav from 'components/QuickNav'
-import withIframeHook from 'components/hoc/withIFrameHook'
+import withIframeHook from '../components/hoc/withIFrameHook'
 import index from 'data/algolia.js'
 
 class HelpPageTemplate extends React.Component {

--- a/src/templates/HelpArticle.jsx
+++ b/src/templates/HelpArticle.jsx
@@ -6,6 +6,7 @@ import Link from 'components/Link'
 import SearchResults from 'components/SearchResults'
 import ArticlesList from 'components/ArticlesList'
 import QuickNav from 'components/QuickNav'
+import withIframeHook from 'components/hoc/withIFrameHook'
 import index from 'data/algolia.js'
 
 class HelpPageTemplate extends React.Component {
@@ -275,4 +276,4 @@ export const pageQuery = graphql`
   }
 `
 
-export default HelpPageTemplate
+export default withIframeHook(HelpPageTemplate)

--- a/src/templates/HelpArticle.jsx
+++ b/src/templates/HelpArticle.jsx
@@ -6,7 +6,7 @@ import Link from 'components/Link'
 import SearchResults from 'components/SearchResults'
 import ArticlesList from 'components/ArticlesList'
 import QuickNav from 'components/QuickNav'
-import withIframeHook from 'components/hoc/withIFrameHook'
+import withIframeHook from 'components/hoc/withIframeHook'
 import index from 'data/algolia.js'
 
 class HelpPageTemplate extends React.Component {

--- a/src/templates/HelpArticle.jsx
+++ b/src/templates/HelpArticle.jsx
@@ -8,13 +8,6 @@ import ArticlesList from 'components/ArticlesList'
 import QuickNav from 'components/QuickNav'
 import index from 'data/algolia.js'
 
-const HELP_DRAWER_COOKIE = 'help_drawer_cookie'
-const DRAWER_CLASSNAME = 'drawer'
-const MESSAGES = {
-  HELP_DRAWER_READY: 'drawer_ready',
-  HELP_DRAWER_REQUEST: 'drawer_request',
-}
-
 class HelpPageTemplate extends React.Component {
   constructor(props) {
     super(props)
@@ -101,37 +94,6 @@ class HelpPageTemplate extends React.Component {
         const anchor = document.getElementById(window.location.hash.substr(1))
         window.scrollTo(0, anchor.getBoundingClientRect().top)
       }
-    }
-    // if loaded in iframe
-    if (window.parent !== window) {
-      this.initHelpDrawer()
-    }
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('message', this.onPostMessage)
-  }
-
-  initHelpDrawer() {
-    if (HELP_DRAWER_COOKIE in sessionStorage) {
-      // cookie set from before, no need to wait
-      this.onHelpDrawerConfirmed()
-    } else {
-      // wait for parent msg
-      window.addEventListener('message', this.onPostMessage, '*')
-    }
-  }
-
-  onHelpDrawerConfirmed() {
-    document.body.classList.add(DRAWER_CLASSNAME) // changes styling
-    window.parent.postMessage(MESSAGES.HELP_DRAWER_READY, '*') // notify parent
-  }
-
-  onPostMessage = (event) => {
-    if (event.data === MESSAGES.HELP_DRAWER_REQUEST) {
-      sessionStorage[HELP_DRAWER_COOKIE] = true; // set session cookie for next time
-      window.removeEventListener('message', this.onPostMessage) // no more listen
-      this.onHelpDrawerConfirmed()
     }
   }
 


### PR DESCRIPTION
Follow up on https://github.com/getredash/website/pull/200#issuecomment-463638668.

### What changed
Reverted previous postMessage communication.
Instead determining "drawer" mode by detecting if loaded in iframe.

### Why it's better
Since the classname is added directly on `componentDidMount` there is no flicker visible at all.

Now the parent window simply loads the page in iframe without any trickery.