### PR TITLE
Remove current page title from breadcrumbs

### DIFF
--- a/src/templates/HelpArticle.jsx
+++ b/src/templates/HelpArticle.jsx
@@ -173,8 +173,7 @@ class HelpPageTemplate extends React.Component {
                     {Parent.frontmatter.title}
                   </Link>
                 </li>
-              )}{' '}
-              <li className="active">{frontmatter.title}</li>
+              )}
             </ol>
 
             <div className="row">


### PR DESCRIPTION
Before | After
------------ | -------------
![image](https://user-images.githubusercontent.com/71468/52811646-45787900-309e-11e9-88c4-5b9b8bdf72a2.png) | ![image](https://user-images.githubusercontent.com/71468/52811607-2e398b80-309e-11e9-8f03-3e6adbad455c.png)
![image](https://user-images.githubusercontent.com/71468/52811701-66d96500-309e-11e9-89ec-9dbcbc3e2126.png) | ![image](https://user-images.githubusercontent.com/71468/52811729-79539e80-309e-11e9-932f-06b1e21ab9dd.png)

The biggest difference in in mobile/drawer mode.