### PR TITLE
Contributor card layout fixes

### DIFF
--- a/src/scss/_components/_page-about.scss
+++ b/src/scss/_components/_page-about.scss
@@ -1,5 +1,5 @@
 .contributor-list--team {
-  justify-content: space-around;
+  justify-content: center;
 
   .contributor-card {
     min-width: 245px;

--- a/src/scss/_components/_section.scss
+++ b/src/scss/_components/_section.scss
@@ -311,6 +311,8 @@
 
     .contributor-card {
       min-width: 100%;
+      margin-left: 0;
+      margin-right: 0;
     }
   }
 


### PR DESCRIPTION
#### Before (off-center)
<img width="200" src="https://user-images.githubusercontent.com/486954/53290716-ba3f6780-37b0-11e9-8c2e-0af0b70b5049.png" />

#### After (centered)

<img width="200" src="https://user-images.githubusercontent.com/486954/53290717-ba3f6780-37b0-11e9-9cae-4b018f96de69.png" />

----------------------

#### Before (too much space between)

<img width="400" src="https://user-images.githubusercontent.com/486954/53290719-ba3f6780-37b0-11e9-8b47-4317d0696c2d.png" />

#### After (normal spacing)
<img width="400" src="https://user-images.githubusercontent.com/486954/53290718-ba3f6780-37b0-11e9-8443-c78efff48766.png" />
