### PR TITLE
Removed legacy scrollTo code

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,11 +1,3 @@
 exports.onRouteUpdate = ({ location }) => {
-  window.analytics && window.analytics.page();
-  if (
-    typeof window !== 'undefined' &&
-    (!location.action || location.action === 'push')
-  ) {
-    setTimeout(() => {
-      window.scrollTo(0, 0)
-    })
-  }
+  window.analytics && window.analytics.page()
 }


### PR DESCRIPTION
Help doc links rely on url anchoring but reportedly sometimes it doesn't work.
Most likely, the code in `gatsby-browser.js` is the cause.

```js
if (
  typeof window !== 'undefined' &&
  (!location.action || location.action === 'push')
) {
  setTimeout(() => {
    window.scrollTo(0, 0)
  })
}
```

My guess is that the above code is meant to make sure navigation to pages will scroll to top (single page app requirement) unless navigated "back" (hence the location.action check).
BUT, from what I understand, Gatsby deals with this on it's own with [gatsby-react-router-scroll](https://www.npmjs.com/package/gatsby-react-router-scroll) and I also tested this PR and found no prob.