### PR TITLE
Fixed Help dropdown clickable area

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -88,18 +88,17 @@ class Header extends React.Component {
               <li
                 className={`dropdown ${this.state.dropdownOpen ? 'open' : ''}`}
               >
-                <Link
-                  to="#"
+                <a
+                  href="#"
                   className="dropdown-toggle"
                   data-toggle="dropdown"
                   role="button"
                   aria-haspopup="true"
                   aria-expanded={this.dropdownOpen}
+                  onClick={this.toggleDropdown}
                 >
-                  <span onClick={this.toggleDropdown}>
-                    Help <span className="caret" />
-                  </span>
-                </Link>
+                  Help <span className="caret" />
+                </a>
                 <ul className="dropdown-menu">
                   <li>
                     <Link to="/help/">Knowledge Base</Link>


### PR DESCRIPTION
Fixes https://github.com/getredash/website/issues/221

Swapped the `<Link>` for a `<a>`. No sweat 😎

![Screen Shot 2019-03-13 at 19 00 56](https://user-images.githubusercontent.com/486954/54299002-965a8f00-45c2-11e9-8145-e5ed92656a89.png)
