### PR TITLE
Add E2E Tests doc page

### DIFF
--- a/src/pages/kb/open-source/dev-guide.md
+++ b/src/pages/kb/open-source/dev-guide.md
@@ -26,6 +26,7 @@ Windows users: while it should be possible to run Redash on a Windows machine, w
 * [Debugging a Redash Server on Docker Using Visual Studio Code]({% link _kb/open-source/dev-guide/debugging.md %})
 * [Developer Installation Guide]({% link _kb/open-source/dev-guide/setup.md %}) (recommended for experienced developers)
 * [Using a remote server and installing locally only the frontend dependencies]({% link _kb/open-source/dev-guide/remote-server.md %})
+* [Frontend End-to-End Tests]({% link _kb/open-source/dev-guide/end-to-end-tests.md %})
 
 ## Additional Resources
 

--- a/src/pages/kb/open-source/dev-guide/end-to-end-tests.md
+++ b/src/pages/kb/open-source/dev-guide/end-to-end-tests.md
@@ -1,0 +1,45 @@
+---
+category: dev-guide
+parent_category: open-source
+title: Frontend End-to-End Tests
+slug: end-to-end-tests
+---
+
+{% callout %}
+The E2E tests are based in the [Docker Based Developer Installation]({% link _kb/open-source/dev-guide/docker.md %}), so make sure you have it if need to run our tests locally.
+{% endcallout %}
+
+## Running E2E tests locally
+
+Redash uses Cypress for E2E tests and its dependencies are not installed by default, so first you will need to install them:
+```bash
+npm run cypress:install
+```
+
+Stop your development environment if it's running:
+```bash
+docker-compose stop
+```
+
+If you just want to run the tests and get a report you can run `npm run cypress`. In case you want to create/change tests it's recommended to run the commands separately:
+
+1. Start the server:
+```bash
+npm run cypress start
+```
+2. Seed data:
+```bash
+npm run cypress db-seed
+```
+3. Open Cypress interface:
+```bash
+npm run cypress open
+```
+5. Change what you need and explore Cypress, you can refer to [their documentantion](https://docs.cypress.io/). To keep frontend code in sync with the server you can use:
+```bash
+npm run watch
+```
+6. When done, stop the server (this will also reset tests state):
+```bash
+npm run cypress stop
+```

--- a/src/pages/kb/open-source/dev-guide/end-to-end-tests.md
+++ b/src/pages/kb/open-source/dev-guide/end-to-end-tests.md
@@ -5,41 +5,63 @@ title: Frontend End-to-End Tests
 slug: end-to-end-tests
 ---
 
-{% callout %}
-The E2E tests are based in the [Docker Based Developer Installation]({% link _kb/open-source/dev-guide/docker.md %}), so make sure you have it if need to run our tests locally.
-{% endcallout %}
+Redash uses [Cypress]([https://cypress.io](https://www.cypress.io/)) for E2E tests, running as the CI build check "frontend-e2e-tests"  on each pull request.
+Test specs are located in the folder `/client/cypress/integrations`. 
+
+-------------
+
 
 ## Running E2E tests locally
 
-Redash uses Cypress for E2E tests and its dependencies are not installed by default, so first you will need to install them:
-```bash
-npm run cypress:install
-```
+#### Prerequisites
+1. If you haven't already, install Redash's [Docker services]({% link _kb/open-source/dev-guide/docker.md %}) first.
 
-Stop your development environment if it's running:
-```bash
-docker-compose stop
-```
+2. Install Cypress:
+    ```bash
+   npm run cypress:install
+   ```
+3. Stop your development environment, if currently running:
+   ```bash
+   docker-compose stop
+   ```
 
-If you just want to run the tests and get a report you can run `npm run cypress`. In case you want to create/change tests it's recommended to run the commands separately:
+<br />
 
-1. Start the server:
+#### Run tests
+Run the full test suite with a detailed report:
 ```bash
-npm run cypress start
+npm run cypress
 ```
-2. Seed data:
-```bash
-npm run cypress db-seed
-```
-3. Open Cypress interface:
-```bash
-npm run cypress open
-```
-5. Change what you need and explore Cypress, you can refer to [their documentantion](https://docs.cypress.io/). To keep frontend code in sync with the server you can use:
-```bash
-npm run watch
-```
-6. When done, stop the server (this will also reset tests state):
-```bash
-npm run cypress stop
-```
+<br />
+
+#### Create, edit and debug tests
+If you wish to change, observe and debug tests as they run, we recommend using the Cypress interface.
+
+1. Start the Cypress server:
+   ```bash
+   npm run cypress start
+   ```
+2. Seed initial data:
+   ```bash
+   npm run cypress db-seed
+   ```
+3. Open the Cypress interface:
+   ```bash
+   npm run cypress open
+   ```
+   Now you can select and run individual test suites, set breakpoints and logs, utilize Chrome Developer Tools, etc. You can refer to [their documentantion](https://docs.cypress.io/).
+
+   Any changes to a test will trigger its rerun.
+If you make changes to Redash frontend code though, make sure to keep it in sync by running the following command in parallel:
+   ```bash
+   npm run watch
+   ```
+4. When you're done, stop the server:
+   ```bash
+   npm run cypress stop
+   ```
+   This will also reset tests state.
+
+<br /><br />
+
+For any question on installations, troubleshooting and best practices, please refer to our [forum](https://discuss.redash.io).


### PR DESCRIPTION
I postponed too much this one :sweat_smile:. This creates a page for E2E Tests documentation with instructions to Run Cypress locally.

I also want to add an "Our Practices" section further (probably in this page). I should do it after some discussion about it. This way we'll have documented our practices for: naming conventions, when to/not to write e2e tests, things to avoid when coding, etc.

Ideas for improvements are, as always, accepted :grin: