### PR TITLE
Update "Docker Based Developer Installation Guide"

### DIFF
--- a/src/pages/kb/open-source/dev-guide/docker.md
+++ b/src/pages/kb/open-source/dev-guide/docker.md
@@ -42,6 +42,12 @@ file to see the full configuration.
 npm install
 ```
 
+### Build Front-End Modules
+
+```bash
+npm run build
+```
+
 ### Create Database
 
 ```bash


### PR DESCRIPTION
I think We need transpile `.less` to `.css` when developing.
I ran `npm run build` to want transpiling `.less` to `.css`.
Is this a correct way?

![redash-doc](https://user-images.githubusercontent.com/2928633/55224186-54347d00-5253-11e9-9905-d0016a41f99f.jpg)