### PR TITLE
Searchbox click - fix issue #230

### DIFF
--- a/src/scss/_components/_forms.scss
+++ b/src/scss/_components/_forms.scss
@@ -55,6 +55,10 @@ $placeholder-opacity: 0;
 		transform: translateY(-50%);
 		top: 50%;
 	}
+	.search-box {
+		position: relative;
+		z-index: 1; // Fix for issue #230
+	}
 	.form-control {
 		padding-left: 50px;
 	}

--- a/src/scss/_components/_forms.scss
+++ b/src/scss/_components/_forms.scss
@@ -54,6 +54,7 @@ $placeholder-opacity: 0;
 		left: 35px;
 		transform: translateY(-50%);
 		top: 50%;
+		z-index: 2;
 	}
 	.search-box {
 		position: relative;


### PR DESCRIPTION
Fixes #230.

Because of the h3 padding hack (for proper auto-scrolled positioning) the bottom section overlaps the searchbar and obscures its clickable area.

![Screen Shot 2019-04-11 at 12 37 36](https://user-images.githubusercontent.com/486954/55947146-9f3c9000-5c56-11e9-8f09-fe19ae5144d9.png)

There are many ways to approach this. I went for the safest (in terms of causing new problems).

Verified on Linux Chrome.