### PR TITLE
Fixed h3 spacing issue #210

### DIFF
--- a/src/scss/_components/_kb.scss
+++ b/src/scss/_components/_kb.scss
@@ -69,7 +69,7 @@ div.docs table {
 }
 
 div.docs h2,
-h3 {
+div.docs h3 {
   padding-top: 80px;
   margin-top: -80px;
 }


### PR DESCRIPTION
Fixes #210

This spacing is supposed to affect only Knowledge Base titles (so that anchors would be spaced correctly under the fixed header).

Before:

![Screen Shot 2019-04-13 at 13 15 44](https://user-images.githubusercontent.com/486954/56078261-b615ea80-5dee-11e9-8c01-92a8e2b24355.png)

After:

![Screen Shot 2019-04-13 at 13 15 32](https://user-images.githubusercontent.com/486954/56078263-ba420800-5dee-11e9-9b52-256059dcdd58.png)

