### PR TITLE
Fixed title line height

### DIFF
--- a/src/scss/_components/_kb.scss
+++ b/src/scss/_components/_kb.scss
@@ -27,8 +27,7 @@
 }
 
 .h2--kb-page-title {
-  margin-top: 0;
-  line-height: 2.5;
+  margin-top: 10px;
 }
 
 code {


### PR DESCRIPTION
Noticed that multi line title looks bad. Fixed it.

Before | After
------------ | -------------
<img src="https://user-images.githubusercontent.com/486954/56862563-f3fd3c00-69b4-11e9-8d95-a8a726d45efd.png"> | <img src="https://user-images.githubusercontent.com/486954/56862566-fa8bb380-69b4-11e9-9683-8be3fd57afea.png">

------------------

But one line remains unchanged

<img width="400" alt="Screen Shot 2019-04-28 at 12 53 31" src="https://user-images.githubusercontent.com/486954/56862572-0d05ed00-69b5-11e9-9834-c7acf2920712.png">

