### PR TITLE
Scheduled query changes

### DIFF
--- a/src/pages/kb/user-guide/alerts/setting-up-an-alert.md
+++ b/src/pages/kb/user-guide/alerts/setting-up-an-alert.md
@@ -15,11 +15,11 @@ title: Setting Up An Alert
 slug: setting-up-an-alert
 order: 1
 ---
-Redash alerts can notify you when your scheduled queries match some arbitrary criteria. Use them to monitor business data or integrated them with tools like Zapier or IFTTT to trigger business processes like user onbarding or support tickets. 
+Redash alerts can notify you when your [**Scheduled Queries**]({% link _kb/user-guide/querying/scheduling-a-query.md %}) match some arbitrary criteria. Use them to monitor business data or integrated them with tools like Zapier or IFTTT to trigger business processes like user onbarding or support tickets. While Alerts are usually combined with scheduled queries, the Alert criteria will be evaluated every time the query is executed.
 
-{% callout info %}
+{% callout warning %}
 
-While Alerts are usually combined with scheduled queries, the Alert criteria will be evaluated every time the query is executed. A schedule is not necessary but is recommended.
+A query schedule is not necessary but is _highly recommended_ for alerts. If you configure an Alert without a query schedule you will only receive notifications if a user in your organization manually executes a given query.
 
 {% endcallout %}
 

--- a/src/pages/kb/user-guide/dashboards/dashboard-editing.md
+++ b/src/pages/kb/user-guide/dashboards/dashboard-editing.md
@@ -73,7 +73,7 @@ If you want your dashboards to stay fresh but don't want to make scheduled queri
 
 {% callout info %}
 
-Automatic Dashboard Refresh occurs as part of the Redash frontend application. Your refresh schedule is only in-effect as long as a logged-in user has the dashboard open in their browser. To guarantee that your queries are executed regularly (which is important for alerts), you should use a [Scheduled Query]({% link _kb/user-guide/querying/scheduling-a-query.md  %}) instead.
+Automatic Dashboard Refresh occurs as part of the Redash frontend application. Your refresh schedule is only in-effect as long as a logged-in user has the dashboard open in their browser. To guarantee that your queries are executed regularly (which is important for alerts), you should use a [Scheduled Query]({% link _kb/user-guide/querying/scheduling-a-query.md %}) instead.
 
 {% endcallout %}
 


### PR DESCRIPTION
Fixed broken link to the scheduled queries page (extra space breaks the `{% _link %}` behavior. Added stress that Alerts should be configured with scheduled queries.