### PR TITLE
Quick note about CSV downloads

### DIFF
--- a/src/pages/kb/user-guide/querying/download-query-results.md
+++ b/src/pages/kb/user-guide/querying/download-query-results.md
@@ -25,3 +25,9 @@ In the dialog that will open you will find:
 
 - Query API key.
 - Latest results URL in CSV and JSON format. You can also get the Excel format by changing the file type suffix from `json`/`csv` to `xlsx`.
+
+{% callout info %}
+
+The latest results in CSV or JSON format option will not work for queries that use parameters.
+
+{% endcallout %}


### PR DESCRIPTION
Queries with parameters can't be downloaded through the API.

Adding a brief mention of this to avert confusion from customers expecting a cached result to be passed through. As part of this pull request I'd like to include a workaround using the most recent cached query result for a given query ID.