### PR TITLE
Remove bigquery.datasets.list from BigQuery documentation, not valid permission

### DIFF
--- a/src/pages/kb/data-sources/bigquery-setup.md
+++ b/src/pages/kb/data-sources/bigquery-setup.md
@@ -18,8 +18,8 @@ ID.
 You'll need to create a service account from your Google Cloud Console and
 assign it permissions to access BigQuery.
 
-1. Open the [Service accounts page](https://console.developers.google.com/permissions/serviceaccounts). If prompted, select a project. 
-2. Click Create service account. 
+1. Open the [Service accounts page](https://console.developers.google.com/permissions/serviceaccounts). If prompted, select a project.
+2. Click Create service account.
 3. In the Create service account window, type a name for the service account, and select Furnish a new private key. When prompted, select JSON key file type. Then click CREATE.
 
 Don't forget to select the JSON type when generating the key file.  Later,
@@ -35,7 +35,6 @@ Want to create your own role? The permissions you need to assign are:
   * bigquery.jobs.create
   * bigquery.jobs.get
   * bigquery.jobs.update
-  * bigquery.datasets.list
   * bigquery.datasets.get
   * bigquery.tables.list
   * bigquery.tables.get


### PR DESCRIPTION
When attempting to create a custom IAM role based on https://redash.io/help/data-sources/setup/bigquery `BigQuery Permissions and Roles` the permission `bigquery.datasets.list` is not valid.

```
"Permission bigquery.datasets.list is not valid., badRequest"
```

https://cloud.google.com/bigquery/docs/access-control contains a list of all valid permissions.