### PR TITLE
Fixed broken internal links

### DIFF
--- a/src/pages/kb/user-guide/querying/query-filters.md
+++ b/src/pages/kb/user-guide/querying/query-filters.md
@@ -36,7 +36,7 @@ GROUP BY action
 
 ![](/assets/images/docs/gitbook/multifilter_example.png)
 
-You can use Query Filters on dashboards too. By default, the filter widget will appear beside each visualization where the filter has been added to the query. If you'd like to link together the filter widgets into a dashboard-level Query Filter see [these instructions]({% link _kb/user-guide/dashboards/dashboard-editing.md  %}).
+You can use Query Filters on dashboards too. By default, the filter widget will appear beside each visualization where the filter has been added to the query. If you'd like to link together the filter widgets into a dashboard-level Query Filter see [these instructions]({% link _kb/user-guide/dashboards/dashboard-editing.md %}).
 
 ## Limitations
 

--- a/src/pages/kb/user-guide/querying/query-parameters.md
+++ b/src/pages/kb/user-guide/querying/query-parameters.md
@@ -51,7 +51,7 @@ Prior to Redash version 7, the parameter settings pane in the Query Editor inclu
 
 {% callout danger %}
 
-Query Parameters only work within Redash and are not supported in embeds or shared dashboards. Also, a Redash user must have [Full Access]({% link _kb/user-guide/users/permissions-groups.md  %}) permission to the data source to use Query Parameters.
+Query Parameters only work within Redash and are not supported in embeds or shared dashboards. Also, a Redash user must have [Full Access]({% link _kb/user-guide/users/permissions-groups.md %}) permission to the data source to use Query Parameters.
 
 {% endcallout %}
 


### PR DESCRIPTION
Fixed #255 

Found 2 instances in which the `{% link url %}` had an extra space.

### Staring at empty space
<img src="https://user-images.githubusercontent.com/486954/60286814-fb8b8380-9918-11e9-891d-bb7df22257da.jpg" width=300 />
