### PR TITLE
Minor tweaks so new dev setup works with a single terminal session

### DIFF
--- a/src/pages/kb/open-source/dev-guide/docker.md
+++ b/src/pages/kb/open-source/dev-guide/docker.md
@@ -29,7 +29,7 @@ cd redash/
 Once you have the above setup, you need to create the Docker services:
 
 ```bash
-docker-compose up
+docker-compose up -d
 ```
 
 This will build the Docker images and fetch some prebuilt images and then start the services
@@ -84,7 +84,8 @@ the Celery workers run:
 docker-compose restart worker
 ```
 
-(or just stop `docker-compose up` and run it again)
+(or just stop all the running services with `docker-compose stop` then run them again
+with `docker-compose up -d`)
 
 ### Installing new Python packages (requirements.txt)
 


### PR DESCRIPTION
It was a bit disconcerting the first time going through this, having the command take over the terminal session and the instructions not being clear that this was intended.

This PR adjusts things so the startup is backgrounded instead, allowing the user to continue with the instructions.

An alternative approach, would be to mention after the `docker-compose up` that the user should leave that command running then open a new terminal window to continue on.  Happy to update this PR to use that approach instead, if it's preferred.