### PR TITLE
Revised to reflect current behavior as identified #3217.

### DIFF
--- a/src/pages/kb/user-guide/querying/writing-queries.md
+++ b/src/pages/kb/user-guide/querying/writing-queries.md
@@ -55,12 +55,9 @@ Auto Complete looks for schema tokens, query syntax identifiers (like `SELECT` o
 
 ## Published vs Unpublished Queries
 
-By default each query starts as an unpublished draft, which means that:
+By default each query starts as an unpublished draft, which means that it can't be included on dashboards, embedded outside the application or used with alerts.
 
-- Only the user who created this query can see it in the "All Queries" list or in search results.
-- You can't add visualizations from an unpublished query to dashboards or use it in alerts.
-
-To publish a query, give it a name or click the `Publish` button. It's also possible to unpublish a published query by clicking on the `Unpublish` button in the query menu.
+To publish a query, give it a name or click the `Publish` button. It's also possible to unpublish a published query by clicking on the `Unpublish` button in the query menu. Doing so will remove it from all dashboards, disable existing embed links and alerts.
 
 
 ## Archiving a Query


### PR DESCRIPTION
See [this issue](https://github.com/getredash/redash/issues/3217).

There's a mismatch right now between the docs and the application behavior. One will need to be updated to match the other. Merging this PR will make the documentation match the current behavior of the app. The team may choose instead to revert the application behavior to match the current docs, in which case this PR can be closed.