### PR TITLE
Updates to API documentation

### DIFF
--- a/src/pages/kb/user-guide/integrations-and-api/api.md
+++ b/src/pages/kb/user-guide/integrations-and-api/api.md
@@ -18,7 +18,7 @@ Whenever possible we recommend using a Query API key.
 
 ## Accessing with Python
 
-We provide a light wrapper around the Redash API called `redash-toolbelt`. The source code is hosted on [Github](https://github.com/getredash/redash-toolbelt). The `examples` folder in that repo includes useful demos, such as:
+We provide a light wrapper around the Redash API called `redash-toolbelt`. It's a work-in-progress. The source code is hosted on [Github](https://github.com/getredash/redash-toolbelt). The `examples` folder in that repo includes useful demos, such as:
 
 + [Poll for Fresh Query Results (including parameters)](https://github.com/getredash/redash-toolbelt/blob/master/redash_toolbelt/examples/refresh_query.py)
 + [Refresh an entire Dashboard](https://github.com/getredash/redash-toolbelt/blob/master/redash_toolbelt/examples/refresh_dashboard.py)

--- a/src/pages/kb/user-guide/integrations-and-api/api.md
+++ b/src/pages/kb/user-guide/integrations-and-api/api.md
@@ -33,8 +33,8 @@ Below is an incomplete list of Redash's API endpoints as of V9. These may change
 
 Each endpoint is appended to your Redash base URL. For example:
 
-- `app.redash.io/<slug>/api`
-- `redash.example.com/api`
+- `https://app.redash.io/<slug>`
+- `https://redash.example.com`
 
 ### Queries
 

--- a/src/pages/kb/user-guide/integrations-and-api/api.md
+++ b/src/pages/kb/user-guide/integrations-and-api/api.md
@@ -51,8 +51,8 @@ Each endpoint is appended to your Redash base URL. For example:
 
 
 `/api/queries/<id>/results`
-+ POST: Refreshes a query and responds with a query task result (job).
-	- If your request JSON includes a `max_age` key (integer value in seconds), a cached result will be provided if one is available.
++ POST: Initiates a new query execution or returns a cached result.
+	- Include a `max_age` key (integer value in seconds) to prefer a cached result within the specified interval. A cached result is returned if available. If `max_age` is omitted or `0` a new execution will begin and a query execution task (job) will be returned.. 
 	- If passing parameters, they must be included in the JSON request body as a `parameters` object.
 
 {% callout info %}

--- a/src/pages/kb/user-guide/integrations-and-api/api.md
+++ b/src/pages/kb/user-guide/integrations-and-api/api.md
@@ -28,27 +28,36 @@ We provide a light wrapper around the Redash API called `redash-toolbelt`. The s
 ## Common Endpoints
 
 {% callout danger %}
-Below is an incomplete list of Redash's internal API endpoints as of V9. These may change in future versions of Redash.
+Below is an incomplete list of Redash's API endpoints as of V9. These may change in future versions of Redash.
 {% endcallout %}
+
+Each endpoint is appended to your Redash base URL. For example:
+
+- `app.redash.io/<slug>/api`
+- `redash.example.com/api`
 
 ### Queries
 
-`api/queries`
+`/api/queries`
 + GET: Returns a paginated array of query objects.
 	- Includes the most recent `query_result_id` for non-parameterized queries.
 + POST: Create a new query object
 
-`api/queries/<id>`
+`/api/queries/<id>`
 + GET: Returns an individual query object
 + POST: Edit an existing query object.
 + DELETE: Archive this query. 
 
+
+
+`/api/queries/<id>/results`
++ POST: Refreshes a query and responds with a query task result (job).
+	- If your request JSON includes a `max_age` key (integer value in seconds), a cached result will be provided if one is available.
+	- If passing parameters, they must be included in the JSON request body as a `parameters` object.
+
 {% callout info %}
 
-There are two endpoints that can refresh a query with parameters. `/refresh` and `/results`.
-
-`/refresh` accepts parameter values in its query string.
-`/results` accepts parameter values in the request JSON request body.
+Here's an example JSON object including different parameter types:
 
 ```
 { 
@@ -65,15 +74,7 @@ There are two endpoints that can refresh a query with parameters. `/refresh` and
 
 {% endcallout %}
 
-`api/queries/<id>/refresh`
-+ POST: Refreshes a query and responds with a query task result (job)
-	- If passing parameters, they must be included in the query string preceded by `p_`.
-
-`api/queries/<id>/results`
-+ POST: Refreshes a query and responds with a query task result (job).
-	- If passing parameters, they must be included in the JSON request body as a `parameters` object.
-
-`api/jobs/<job_id>`
+`/api/jobs/<job_id>`
 + GET: Returns a query task result (job)
 	+ Possible statuses:
 		- 1 == PENDING (waiting to be executed)
@@ -83,17 +84,19 @@ There are two endpoints that can refresh a query with parameters. `/refresh` and
 		- 5 == CANCELLED
 	+ When status is success, the job will include a `query_result_id`
 
-`api/query_results/<query_result_id>`
+`/api/query_results/<query_result_id>`
 + GET: Returns a query result
 	- Appending a filetype of `.csv` or `.json` to this request will return a downloadable file. If you append your `api_key` in the query string, this link will work for non-logged-in users.
 
 ### Dashboards
 
-`api/dashboards`
+`/api/dashboards`
 + GET: Returns a paginated array of dashboard objects.
 + POST: Create a new dashboard object
 
-`api/dashboards/<dashboard_id>`
+`/api/dashboards/<dashboard_slug>`
 + GET: Returns an individual dashboard object.
+
+`/api/dashboards/<dashboard_id>`
 + POST: Edit an existing dashboard object.
 + DELETE: Archive this dashboard


### PR DESCRIPTION
Fixing problems with: ebe13531147d6e9aaa4ac93c31f10b03b5200d30

- API is not "internal". It's just the API.
- Endpoints should be preceded by a forward slash `/`
- No need to document the `/refresh` API as it's slated for removal.
- The `/api/results` endpoint can return a cached result sometimes.
- `/api/dashboards/<dashboard_id>` only works for POST and DELETE
- `/api/dashboards/<dashboard_slug>` is required for a GET

## Related Tickets & Documents

Closes https://github.com/getredash/website/issues/373