### PR TITLE
Updates BQ doc to reflect the 5000 token schema limit

### DIFF
--- a/src/pages/kb/data-sources/bigquery.md
+++ b/src/pages/kb/data-sources/bigquery.md
@@ -12,7 +12,7 @@ On the BigQuery Data Source setup screen, the **Project ID** and **JSON Key File
 
 ![](/assets/images/docs/gitbook/bigquery_mandatories.PNG)
 
-+ If your database schema exceeds \~2500 tokens, untick the **Load Schema** box to stop Redash from loading it to the Query Editor screen. Many browsers will slow down or crash if the schema is too big.
++ If your database schema exceeds 5000 tokens, untick the **Load Schema** box to stop Redash from loading it to the Query Editor screen. Many browsers will slow down or crash if the schema is too big.
 
 + Since BigQuery 2.0, BigQuery supports its Legacy SQL syntax or [Standard SQL Syntax](https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql). Redash supports both, but Standard SQL is the default.  This preference applies at the Data Source-level by toggling the **Use Standard SQL** box. Your selection here is passed to BigQuery along with your query text. If some of your queries use Legacy SQL and others use Standard SQL, you can create two data sources.
 


### PR DESCRIPTION
While investigating https://github.com/getredash/website/issues/393 I saw that this page and [this one](https://redash.io/help/user-guide/querying/writing-queries) disagree about the token limit for Auto Complete. This PR makes the BQ doc match the `writing-queries` page.

