### PR TITLE
Document HTML escape behavior in tables

### DIFF
--- a/src/pages/kb/user-guide/visualizations/table-visualizations.md
+++ b/src/pages/kb/user-guide/visualizations/table-visualizations.md
@@ -31,7 +31,7 @@ Redash is sensitive to the data types that are common to most databases: text, n
 
 {% callout info %}
 
-Redash doesn't escape HTML markup in query results by default. So you may see odd effects if a query returns string fields that include HTML (e.g. from a web scraper). Toggle the **Allow HTML content** setting in the visualization editor to escape HTML characters.
+Redash sanitizes HTML in query results. But if any HTML tags remain they are not escaped by default. Thus you may see odd effects if a query result includes string fields that include HTML (e.g. from a web scraper). Toggle the **Allow HTML content** setting in the visualization editor to escape HTML characters.
 
 {% endcallout %}
 

--- a/src/pages/kb/user-guide/visualizations/table-visualizations.md
+++ b/src/pages/kb/user-guide/visualizations/table-visualizations.md
@@ -29,6 +29,12 @@ You can:
 
 Redash is sensitive to the data types that are common to most databases: text, numbers, dates and booleans. But it also has special support for non-standard column types like JSON documents, images, and links.
 
+{% callout info %}
+
+Redash doesn't escape HTML markup in query results by default. So you may see odd effects if a query returns string fields that include HTML (e.g. from a web scraper). Toggle the **Allow HTML content** setting in the visualization editor to escape HTML characters.
+
+{% endcallout %}
+
 ## **Common Data Types**
 
 Redash will render a column as text if your underlying data source does not provide type information. But you can force it to use arbitrary types using the table visualization editor. This is especially useful for sources like SQLite, Google Sheets, or CSV files where type data is not available. You can, for example:


### PR DESCRIPTION
## Type of PR

- [x] Add

## Description

Details the "Allow HTML Content" toggle in the table viz editor and gives an example use-case.

## Screenshots

### Before
<img width="764" alt="before" src="https://user-images.githubusercontent.com/17067911/80244140-12c8f980-862e-11ea-8abc-2c3d6ecfbd4c.png">

### After
<img width="781" alt="after" src="https://user-images.githubusercontent.com/17067911/80244149-19577100-862e-11ea-8c7d-992e5d851e26.png">

## Related Tickets & Documents
Closes https://github.com/getredash/website/issues/140