### PR TITLE
Update Jira doc username definition

### DIFF
--- a/src/pages/kb/data-sources/jira.md
+++ b/src/pages/kb/data-sources/jira.md
@@ -7,7 +7,7 @@ slug: jira-ds
 
 # Setup
 
-You need a **Username** and **[API Token](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)** to connect to Jira. The token behaves like a password. 
+You need a **Username** (the email address you use to login) and **[API Token](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)** to connect to Jira. The token behaves like a password. 
 
 Your username is the email address you use to login.
 

--- a/src/pages/kb/data-sources/jira.md
+++ b/src/pages/kb/data-sources/jira.md
@@ -9,7 +9,6 @@ slug: jira-ds
 
 You need a **Username** (the email address you use to login) and **[API Token](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)** to connect to Jira. The token behaves like a password. 
 
-Your username is the email address you use to login.
 
 {% callout warning %}
 

--- a/src/pages/kb/data-sources/jira.md
+++ b/src/pages/kb/data-sources/jira.md
@@ -9,6 +9,8 @@ slug: jira-ds
 
 You need a **Username** and **[API Token](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)** to connect to Jira. The token behaves like a password. 
 
+Your username is the email address you use to login.
+
 {% callout warning %}
 
 Before Redash V8 the JIRA setup screen asked for a password. You still need an API token to connect successfully. Use your API token instead of your password.


### PR DESCRIPTION
## Type of PR
- [x] Add

## Description

After some debugging with a customer this evening we determined that the username for Jira is the user email address. The API doesn't raise authentication errors, though, so this wasn't obvious.

[Relevant JIRA API Doc](https://developer.atlassian.com/server/jira/platform/basic-authentication/):

> ## No authentication challenge
>
> Because Jira permits a default level of access to anonymous users, it does not supply a typical authentication challenge. 

Adding a reference to this to help future users.

## Related Tickets & Documents

Closes #406 