### PR TITLE
Query Parameters doc page: update youtube embed

### DIFF
--- a/src/pages/kb/user-guide/querying/query-parameters.md
+++ b/src/pages/kb/user-guide/querying/query-parameters.md
@@ -12,7 +12,7 @@ toc: true
 order: 3
 ---
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/CY3N8fT2To4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/02iQXd2Ouos" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 With parameters you can substitute values into your query at runtime without having to **Edit Source**. Any string between double curly braces `{{ }}` will be treated like a parameter. A widget will appear above the results pane so you change the parameter value.
 


### PR DESCRIPTION
## Type of PR

- [x] Change

## Description

On June 20th, 2020 we updated the Query Parameters youtube video. We also removed the previous version. This PR updates the embed code to point at the new video since the old one is no longer available.

## Related Tickets & Documents

Closes #439 