### PR TITLE
Deleting a dashboard with the API requires the slug (not the dashboard id)

### DIFF
--- a/src/pages/kb/user-guide/integrations-and-api/api.md
+++ b/src/pages/kb/user-guide/integrations-and-api/api.md
@@ -96,7 +96,8 @@ Here's an example JSON object including different parameter types:
 
 `/api/dashboards/<dashboard_slug>`
 + GET: Returns an individual dashboard object.
++ DELETE: Archive this dashboard
 
 `/api/dashboards/<dashboard_id>`
 + POST: Edit an existing dashboard object.
-+ DELETE: Archive this dashboard
+


### PR DESCRIPTION
Deleting a dashboard with the API wants the slug (not the dashboard id)