### PR TITLE
Update dashboard api doc to use the id instead of slug

### DIFF
--- a/src/pages/kb/user-guide/integrations-and-api/api.md
+++ b/src/pages/kb/user-guide/integrations-and-api/api.md
@@ -94,10 +94,8 @@ Here's an example JSON object including different parameter types:
 + GET: Returns a paginated array of dashboard objects.
 + POST: Create a new dashboard object
 
-`/api/dashboards/<dashboard_slug>`
-+ GET: Returns an individual dashboard object.
-+ DELETE: Archive this dashboard
-
 `/api/dashboards/<dashboard_id>`
++ GET: Returns an individual dashboard object.
 + POST: Edit an existing dashboard object.
++ DELETE: Archive this dashboard
 


### PR DESCRIPTION
**To be merged after getredash/redash#1009 be released**

After that PR the dashboard routes use the `id` and not the `slug`.