### PR TITLE
Update Cypress docs

### DIFF
--- a/src/pages/kb/open-source/dev-guide/end-to-end-tests.md
+++ b/src/pages/kb/open-source/dev-guide/end-to-end-tests.md
@@ -16,11 +16,7 @@ Test specs are located in the folder `/client/cypress/integrations`.
 #### Prerequisites
 1. If you haven't already, install Redash's [Docker services]({% link _kb/open-source/dev-guide/docker.md %}) first.
 
-2. Install Cypress:
-    ```bash
-   npm run cypress:install
-   ```
-3. Stop your development environment, if currently running:
+2. Stop your development environment, if currently running:
    ```bash
    docker-compose stop
    ```
@@ -41,11 +37,7 @@ If you wish to change, observe and debug tests as they run, we recommend using t
    ```bash
    npm run cypress start
    ```
-2. Seed initial data:
-   ```bash
-   npm run cypress db-seed
-   ```
-3. Open the Cypress interface:
+2. Open the Cypress interface:
    ```bash
    npm run cypress open
    ```
@@ -56,11 +48,18 @@ If you make changes to Redash frontend code though, make sure to keep it in sync
    ```bash
    npm run watch
    ```
-4. When you're done, stop the server:
+3. When you're done, stop the server:
    ```bash
    npm run cypress stop
    ```
    This will also reset tests state.
+   
+In case it's needed to rebuild the docker images (e.g.: you pulled a new version with new packages or added some yourself), rebuild Cypress:
+ ```bash
+ npm run cypress build
+ ```
+ 
+ **Note:** Any Docker Compose command can be executed directly with the "cypress" project name (`docker-compose -p cypress`)
 
 <br /><br />
 

--- a/src/pages/kb/open-source/dev-guide/end-to-end-tests.md
+++ b/src/pages/kb/open-source/dev-guide/end-to-end-tests.md
@@ -5,16 +5,18 @@ title: Frontend End-to-End Tests
 slug: end-to-end-tests
 ---
 
-Redash uses [Cypress]([https://cypress.io](https://www.cypress.io/)) for E2E tests, running as the CI build check "frontend-e2e-tests"  on each pull request.
-Test specs are located in the folder `/client/cypress/integrations`. 
+Redash uses [Cypress](<[https://cypress.io](https://www.cypress.io/)>) for E2E
+tests, running as the CI build check "frontend-e2e-tests" on each pull request.
+Test specs are located in the folder `/client/cypress/integrations`.
 
--------------
-
+---
 
 ## Running E2E tests locally
 
 #### Prerequisites
-1. If you haven't already, install Redash's [Docker services]({% link _kb/open-source/dev-guide/docker.md %}) first.
+
+1. If you haven't already, install Redash's [Docker
+   services]({% link _kb/open-source/dev-guide/docker.md %}) first.
 
 2. Stop your development environment, if currently running:
    ```bash
@@ -24,43 +26,61 @@ Test specs are located in the folder `/client/cypress/integrations`.
 <br />
 
 #### Run tests
+
 Run the full test suite with a detailed report:
+
 ```bash
 npm run cypress
 ```
+
 <br />
 
 #### Create, edit and debug tests
-If you wish to change, observe and debug tests as they run, we recommend using the Cypress interface.
+
+If you wish to change, observe and debug tests as they run, we recommend using
+the Cypress interface.
 
 1. Start the Cypress server:
    ```bash
    npm run cypress start
    ```
 2. Open the Cypress interface:
+
    ```bash
    npm run cypress open
    ```
-   Now you can select and run individual test suites, set breakpoints and logs, utilize Chrome Developer Tools, etc. You can refer to [their documentantion](https://docs.cypress.io/).
 
-   Any changes to a test will trigger its rerun.
-If you make changes to Redash frontend code though, make sure to keep it in sync by running the following command in parallel:
+   Now you can select and run individual test suites, set breakpoints and logs,
+   utilize Chrome Developer Tools, etc. You can refer to
+   [their documentantion](https://docs.cypress.io/).
+
+   Any changes to a test will trigger its rerun. If you make changes to Redash
+   frontend code though, make sure to keep it in sync by running the following
+   command in parallel:
+
    ```bash
    npm run watch
    ```
+
 3. When you're done, stop the server:
+
    ```bash
    npm run cypress stop
    ```
+
    This will also reset tests state.
-   
-In case it's needed to rebuild the docker images (e.g.: you pulled a new version with new packages or added some yourself), rebuild Cypress:
- ```bash
- npm run cypress build
- ```
- 
- **Note:** Any Docker Compose command can be executed directly with the "cypress" project name (`docker-compose -p cypress`)
+
+In case it's needed to rebuild the docker images (e.g.: you pulled a new version
+with new packages or added some yourself), rebuild Cypress:
+
+```bash
+npm run cypress build
+```
+
+**Note:** Any Docker Compose command can be executed directly with the "cypress"
+project name (`docker-compose -p cypress`)
 
 <br /><br />
 
-For any question on installations, troubleshooting and best practices, please refer to our [forum](https://discuss.redash.io).
+For any question on installations, troubleshooting and best practices, please
+refer to our [forum](https://discuss.redash.io).


### PR DESCRIPTION
Update Cypress docs with some of the changes we had recently:
- Cypress is now a dev dependency, so no need to `npm run cypress:install`
- `db-seed` command was incorporated in `npm run cypress start`
- `start` command no longer builds, so `npm run cypress build` was added

For review check https://github.com/getredash/website/pull/512/commits/0fbec657d81c2a42a0cb2cb74c7ada6d84a5c332