### PR TITLE
Revise zapier instructions: where to find user id

### DIFF
--- a/src/pages/kb/user-guide/integrations-and-api/creating-a-zap.md
+++ b/src/pages/kb/user-guide/integrations-and-api/creating-a-zap.md
@@ -17,7 +17,10 @@ Here's a short example of connecting Redash to Zapier and creating a new Zap:
 3. Choose a trigger - for now, we have only "New Query Results" in there, this means the Zap will get triggered everytime a new line is added to the results set of your query. The free Zapier account supports checking for new results every 15 minutes so you should schedule the query to refresh according to the frequency in Zapier. 
 4. Connect your Redash account to Zapier: 
     1. Full domain of your Redash account (Something like:  `https://app.redash.io/myorg/` or `https://redash.myorg.com/` (note the slash at the end)) 
-    2. Your User ID - go to your account in Redash, the number in the URL just after /users/ is your User ID, i.e.  `https://app.redash.io/myorg/users/{user id}`
+    2. Your User ID - go to Redash settings and hover over your username on the **Users** tab. The number in the URL just after /users/ is your User ID, i.e.  `https://app.redash.io/myorg/users/{user id}`. 
+    {% callout warning %}
+    You must be a member of the admin group to see the users list.
+    {% endcallout %}
     3. API key - also in your user settings, select the API KEY tab and copy it from there ![](/assets/images/docs/gitbook/user_api_key.png)
     4. Test your connection! 
 5. Select the query you want to get the Zap for by entering the query ID (`https://app.redash.io/myorg/queries/{query id}`) 

--- a/src/pages/kb/user-guide/integrations-and-api/creating-a-zap.md
+++ b/src/pages/kb/user-guide/integrations-and-api/creating-a-zap.md
@@ -5,32 +5,51 @@ helpscout_url: https://help.redash.io/article/130-creating-a-zap
 title: Creating a Zap in Zapier for New Query Results
 slug: creating-a-zap
 ---
-You can connect Redash to Zapier and trigger an action every time a new line
-is added to your query results - for example, a Slack bot that announces every
-time a new order came in. The best way is to have a scheduled query that
-refreshes frequently so the notification you get is in real-time.
+
+You can connect Redash to Zapier and trigger an action every time a new line is
+added to your query results - for example, a Slack bot that announces every time
+a new order came in. The best way is to have a scheduled query that refreshes
+frequently so the notification you get is in real-time.
 
 Here's a short example of connecting Redash to Zapier and creating a new Zap:
 
-1. Use [this invitation](https://zapier.com/developer/invite/32785/4910e4da7931a8f3a2124ebd85cc352b/) link for the beta Redash trigger app (create an account if needed) and click "Make a Zap" right next to your account area at the top of the page. 
-2. Choose a trigger app - in this case, Redash (it won't be available to you unless you have received and opened the invitation).
-3. Choose a trigger - for now, we have only "New Query Results" in there, this means the Zap will get triggered everytime a new line is added to the results set of your query. The free Zapier account supports checking for new results every 15 minutes so you should schedule the query to refresh according to the frequency in Zapier. 
-4. Connect your Redash account to Zapier: 
-    1. Full domain of your Redash account (Something like:  `https://app.redash.io/myorg/` or `https://redash.myorg.com/` (note the slash at the end)) 
-    2. Your User ID - go to Redash settings and hover over your username on the **Users** tab. The number in the URL just after /users/ is your User ID, i.e.  `https://app.redash.io/myorg/users/{user id}`. 
-    {% callout warning %}
-    You must be a member of the admin group to see the users list.
-    {% endcallout %}
-    3. API key - also in your user settings, select the API KEY tab and copy it from there ![](/assets/images/docs/gitbook/user_api_key.png)
-    4. Test your connection! 
-5. Select the query you want to get the Zap for by entering the query ID (`https://app.redash.io/myorg/queries/{query id}`) 
-6. Select the app you want to perform an action when a new query result is added to your query - Slack is a good option. 
-7. Select an action - for this example, we'll use "Send Channel Message". You'll need to connect your Slack account to Zapier as well if you are logged-in in your browser it'll be pretty instant. 
-8. Enter the channel, message text (you can select different column values from your query), bot/your user in slack, bot name, bot icon emoji or icon url, auto expend links and mentions settings. Bots are cool so you should definitely send the zap as a bot. 
+1. Use
+   [this invitation](https://zapier.com/developer/invite/32785/4910e4da7931a8f3a2124ebd85cc352b/)
+   link for the beta Redash trigger app (create an account if needed) and click
+   "Make a Zap" right next to your account area at the top of the page.
+2. Choose a trigger app - in this case, Redash (it won't be available to you
+   unless you have received and opened the invitation).
+3. Choose a trigger - for now, we have only "New Query Results" in there, this
+   means the Zap will get triggered everytime a new line is added to the results
+   set of your query. The free Zapier account supports checking for new results
+   every 15 minutes so you should schedule the query to refresh according to the
+   frequency in Zapier.
+4. Connect your Redash account to Zapier:
+   1. Full domain of your Redash account (Something like:
+      `https://app.redash.io/myorg/` or `https://redash.myorg.com/` (note the
+      slash at the end))
+   2. Your User ID - go to Redash settings and hover over your username on the
+      **Users** tab. The number in the URL just after /users/ is your User ID,
+      i.e. `https://app.redash.io/myorg/users/{user id}`. {% callout warning %}
+      You must be a member of the admin group to see the users list.
+      {% endcallout %}
+   3. API key - also in your user settings, select the API KEY tab and copy it
+      from there ![](/assets/images/docs/gitbook/user_api_key.png)
+   4. Test your connection!
+5. Select the query you want to get the Zap for by entering the query ID
+   (`https://app.redash.io/myorg/queries/{query id}`)
+6. Select the app you want to perform an action when a new query result is added
+   to your query - Slack is a good option.
+7. Select an action - for this example, we'll use "Send Channel Message". You'll
+   need to connect your Slack account to Zapier as well if you are logged-in in
+   your browser it'll be pretty instant.
+8. Enter the channel, message text (you can select different column values from
+   your query), bot/your user in slack, bot name, bot icon emoji or icon url,
+   auto expend links and mentions settings. Bots are cool so you should
+   definitely send the zap as a bot.
 
 ![](/assets/images/docs/gitbook/zapier_slack_template_wider.png)
 
 **Test your connection and turn your zap on!**
 
 ![](/assets/images/docs/gitbook/zappy_bot.png)
-


### PR DESCRIPTION
A customer on app.redash.io rightfully pointed out that the former instructions don't work anymore. When I click to view my profile the URL now says `https://app.redash.io/<org slug>/users/me`. I believe the only mechanism for viewing a user ID within the interface is from the **Users** tab of settings. This PR updates the documentation to reflect this.