### PR TITLE
Fix: BubbleIQ's website is no longer active resulting in a dead link.

### DIFF
--- a/src/pages/case-studies/bubbleiq/index.jsx
+++ b/src/pages/case-studies/bubbleiq/index.jsx
@@ -47,9 +47,9 @@ const BubbleIQPage = ({ location }) => (
                 </tr>
                 <tr>
                   <td>
-                    <Link to="https://www.bubbleiq.com/" target="_blank">
+
                       BubbleIQ
-                    </Link>
+
                   </td>
                   <td>
                     <img
@@ -86,9 +86,9 @@ const BubbleIQPage = ({ location }) => (
           <div className="col-md-8 col-md-push-2">
             <h2>About BubbleIQ</h2>
             <p>
-              <Link to="https://www.bubbleiq.com/" target="_blank">
+
                 BubbleIQ
-              </Link>{' '}
+{' '}
               helps companies streamline their support workflow by connecting
               helpdesk systems (Zendesk, Salesforce) to real-time chat tools
               (Slack, Drift). This allows companies to provide better support


### PR DESCRIPTION
A customer on app.redash.io reported that the BubbleIQ case study has a dead link to their website. It looks like BubbleIQ folded. This PR maintains the case study but removes the link to their website.