### PR TITLE
Clarify Databricks schemas

### DIFF
--- a/src/pages/kb/data-sources/databricks.md
+++ b/src/pages/kb/data-sources/databricks.md
@@ -15,4 +15,16 @@ This page documents the new Databricks connector introduced in Redash V9. It's c
 * `Name`: name for this connection.
 * `Host` and `HTTP Path`: can be found in the JDBC/ODBC tab of your cluster configuration tab (under Advanced Options).
 * `Access Token`: your personal access token. Can be generated from your User Settings page.
-* `Schemas to Load Metadata For`: which schemas you want to load metadata for (table and column names). You can specify multiple schemas separated by a comma.
+* `Schemas to Load Metadata For`: a comma-separated list of databases that Redash will display in the Schema Viewer on the Query Screen. 
+
+{% callout info %}
+
+If you are not sure what to type into the `Schemas to Load Metadata For` field, you can run the following sql on the query screen to see what options are available:
+
+```
+SHOW DATABASES;
+```
+
+If you leave blank this field then no schema will be retrieved and the Schema Viewer will appear empty. Even if it looks empty, however, you can still query your Databricks instance.
+
+{% endcallout %}

--- a/src/pages/kb/data-sources/databricks.md
+++ b/src/pages/kb/data-sources/databricks.md
@@ -15,4 +15,4 @@ This page documents the new Databricks connector introduced in Redash V9. It's c
 * `Name`: name for this connection.
 * `Host` and `HTTP Path`: can be found in the JDBC/ODBC tab of your cluster configuration tab (under Advanced Options).
 * `Access Token`: your personal access token. Can be generated from your User Settings page.
-* `Schemas to Load Metadata For`: which schemas you want to load metadata for (table and column names). You can specify multiple schemas seperated by a comma.
+* `Schemas to Load Metadata For`: which schemas you want to load metadata for (table and column names). You can specify multiple schemas separated by a comma.


### PR DESCRIPTION
There has been some confusion among Databricks users exactly what to type when setting up the Databricks data source. This PR adds clarifying verbiage.