### PR TITLE
Add link to redash-migrate documentation

### DIFF
--- a/src/pages/kb/faq/eol.md
+++ b/src/pages/kb/faq/eol.md
@@ -25,8 +25,9 @@ analysts within Databricks as our paid offering.
 See the instructions for our [migration tool]. If you have questions please
 contact us through in-app chat or post on our [user forum]. 
 
-[migration tool]: "https://github.com/getredash/redash-toolbelt/tree/master/redash_toolbelt/docs/redash-migrate"
-[user forum]: "https://discuss.redash.io"
+
+[migration tool]: https://github.com/getredash/redash-toolbelt/tree/master/redash_toolbelt/docs/redash-migrate
+[user forum]: https://discuss.redash.io
 
 ## What will happen to my data?
 


### PR DESCRIPTION
Now that getredash/redash-toolbelt#23 has merged, let's point visitors to the EOL FAQ to it.

Our deploy previews are broken, but I've confirmed in local dev that this works as expected:

https://user-images.githubusercontent.com/17067911/136630869-8a75cf1b-2cd6-42f5-baef-790ddbe730f2.mp4



