### PR TITLE
Clarifying dev setup and Google Login

### DIFF
--- a/src/pages/kb/open-source/admin-guide/env-vars-settings.md
+++ b/src/pages/kb/open-source/admin-guide/env-vars-settings.md
@@ -7,7 +7,7 @@ slug: env-vars-settings
 
 Many aspects of the functionality of Redash can be changes with settings.
 Settings are read by `redash.settings` from environment variables which (for
-most installs) can be set in `/opt/redash/current/.env`.
+most installs) can be set in `/opt/redash/.env`.
 
 The follow is a list of settings and what they control:
 

--- a/src/pages/kb/open-source/dev-guide/docker.md
+++ b/src/pages/kb/open-source/dev-guide/docker.md
@@ -28,7 +28,7 @@ cd redash/
 
 ### Set up environment variables
 
-Create a `.env` file at the root and set any environment variables you need. 
+Create a `.env` file at the root and set any environment variables you need.
 
 ```
 $ touch .env
@@ -39,8 +39,7 @@ $ touch .env
 An environment variable named `REDASH_COOKIE_SECRET` is required to run Redash. Read more why Redash uses secret keys [here]({% link _kb/open-source/admin-guide/secrets.md %})
 {% endcallout %}
 
-
-You should include any relevant [environment variables]({% link _kb/open-source/admin-guide/env-vars-settings.md %}) in this file. 
+You should include any relevant [environment variables]({% link _kb/open-source/admin-guide/env-vars-settings.md %}) in this file.
 
 ### Create Docker Services
 

--- a/src/pages/kb/open-source/dev-guide/docker.md
+++ b/src/pages/kb/open-source/dev-guide/docker.md
@@ -26,9 +26,21 @@ git clone https://github.com/getredash/redash.git
 cd redash/
 ```
 
-### Update docker-compose.yml
+### Set up environment variables
 
-Under the `x-redash-environment` key, uncomment the line containing `REDASH_COOKIE_SECRET` and specify a value.
+Create a `.env` file at the root and set any environment variables you need. 
+
+```
+$ touch .env
+```
+
+{% callout info %}
+
+An environment variable named `REDASH_COOKIE_SECRET` is required to run Redash. Read more why Redash uses secret keys [here]({% link _kb/open-source/admin-guide/secrets.md %})
+{% endcallout %}
+
+
+You should include any relevant [environment variables]({% link _kb/open-source/admin-guide/env-vars-settings.md %}) in this file. 
 
 ### Create Docker Services
 

--- a/src/pages/kb/user-guide/users/authentication-options.md
+++ b/src/pages/kb/user-guide/users/authentication-options.md
@@ -43,7 +43,7 @@ Follow these steps to change the environment variables and UI settings to enable
 
 Step 5 below is optional. As of step 4, only visitors with an existing Redash account can sign-in using the Google Login flow. As with Password Login, visitors without an account cannot log-in unless they receive an invitation from an admin.
 
-By following step 5, you may configure Redash to allow any user from  a specified domain to log-in. An account will automatically be created for them if one does not already exist. 
+By following step 5, you may configure Redash to allow any user from a specified domain to log-in. An account will automatically be created for them if one does not already exist.
 
 {% endcallout %}
 

--- a/src/pages/kb/user-guide/users/authentication-options.md
+++ b/src/pages/kb/user-guide/users/authentication-options.md
@@ -38,6 +38,15 @@ Follow these steps to change the environment variables and UI settings to enable
 2. Set the **Authorized Redirect URL(s)** to `http(s)://${REDASH_BASEURL}/oauth/google_callback`.
 3. During setup you will obtain a client id and a client secret. Use these to set the `REDASH_GOOGLE_CLIENT_ID` and `REDASH_GOOGLE_CLIENT_SECRET` environment variables.
 4. Restart your Redash instance.
+
+{% callout info %}
+
+Step 5 below is optional. As of step 4, only visitors with an existing Redash account can sign-in using the Google Login flow. As with Password Login, visitors without an account cannot log-in unless they receive an invitation from an admin.
+
+By following step 5, you may configure Redash to allow any user from  a specified domain to log-in. An account will automatically be created for them if one does not already exist. 
+
+{% endcallout %}
+
 5. Visit **Settings > General**. Complete the _Allowed Google Apps Domains_ box with the domains that should be able to log-in to your Redash instance.
 
 # SAML 2.0


### PR DESCRIPTION
## Description

This PR updates the docker development setup steps now that [#5655](https://github.com/getredash/redash/pull/5655) has merged. Also it clarifies the behaviour of "Allowed Domains" in the Google Login settings.