### PR TITLE
Fix the typo in db setup command

### DIFF
--- a/src/pages/kb/open-source/dev-guide/setup.md
+++ b/src/pages/kb/open-source/dev-guide/setup.md
@@ -69,7 +69,7 @@ with environment variables.
 ## Creating Database Tables
 
 ```bash
-./manage.py database create_tables
+./manage.py database create-tables
 ```
 
 ## Processes


### PR DESCRIPTION
The create tables command should be, `./manage.py database
create-tables`, where it seemed a typo in the existing version of the doc, command is mentioned as `./manage.py database create_tables`.

The underscore should be made a hyphen.

Fixing the command in this PR.
Thanks