### PR TITLE
Correct env file for REDASH_COOKIE_SECRET

### DIFF
--- a/src/pages/kb/open-source/dev-guide/docker.md
+++ b/src/pages/kb/open-source/dev-guide/docker.md
@@ -26,9 +26,13 @@ git clone https://github.com/getredash/redash.git
 cd redash/
 ```
 
-### Update docker-compose.yml
+### Create a .env file
 
-Under the `x-redash-environment` key, uncomment the line containing `REDASH_COOKIE_SECRET` and specify a value.
+Create a file in the base `/redash/` directory and create a file named `.env`. Specify a value for environment variable `REDASH_COOKIE_SECRET`. Example:
+
+```bash
+REDASH_COOKIE_SECRET=my_$3CR3T_string
+```
 
 ### Create Docker Services
 


### PR DESCRIPTION
When I was following the dev guide for getting Redash up and running with Docker, I got this error:

![ERROR: Couldn't find env file: /mnt/c/git/redash/.env](https://user-images.githubusercontent.com/12490173/150464660-88279581-8929-4a8c-b751-fd1fae324b8b.png)

I had just added `REDASH_COOKIE_SECRET` to docker-compose.yml, so instead I moved that env variable to a .env file and everything worked.