### PR TITLE
Create .env file in dev guide

### DIFF
--- a/src/pages/kb/open-source/dev-guide/docker.md
+++ b/src/pages/kb/open-source/dev-guide/docker.md
@@ -26,9 +26,13 @@ git clone https://github.com/getredash/redash.git
 cd redash/
 ```
 
-### Update docker-compose.yml
+### Create .env
 
-Under the `x-redash-environment` key, uncomment the line containing `REDASH_COOKIE_SECRET` and specify a value.
+Create an `.env` file under the project root, and specify a value for `REDASH_COOKIE_SECRET` environment variable.
+
+```
+REDASH_COOKIE_SECRET=mysecret
+```
 
 ### Create Docker Services
 


### PR DESCRIPTION
Looks like we now have `REDASH_COOKIE_SECRET` configured through `.env` rather than docker-compose.yml. 

https://github.com/getredash/redash/blob/master/redash/settings/__init__.py#L66-L70