### PR TITLE
Add Azure AD Oauth Instructions

### DIFF
--- a/src/pages/kb/user-guide/users/authentication-options.md
+++ b/src/pages/kb/user-guide/users/authentication-options.md
@@ -48,6 +48,27 @@ By following step 5, you may configure Redash to allow any user from a specified
 
 5. Visit **Settings > General**. Complete the _Allowed Google Apps Domains_ box with the domains that should be able to log-in to your Redash instance.
 
+# Azure AD (Microsoft Work or School) Login (OAuth)
+
+You can configure Redash to allow to users to login with a Microsoft work or school identity. If they don't have a Redash account yet, one will be automatically created.
+
+Follow these steps to change the environment variables and UI settings to enable Azure AD Login:
+
+1. Register a [new Azure AD application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app). 
+2. Set the **Authorized Redirect URL(s)** to `http(s)://${REDASH_BASEURL}/oauth/azure_callback`.
+3. During application setup you will obtain a client id and a client secret. Use these to set the `REDASH_AZURE_CLIENT_ID` and `REDASH_AZURE_CLIENT_SECRET` environment variables. If your application is single tenant (i.e. you selected 'accounts in this organizational directory only' in application setup), also set the `REDASH_AZURE_TENANT` environment variable.
+4. Restart your Redash instance.
+
+{% callout info %}
+
+Step 5 below is optional. As of step 4, only visitors with an existing Redash account can sign-in using the Azure AD Login flow. As with Password Login, visitors without an account cannot log-in unless they receive an invitation from an admin.
+
+By following step 5, you may configure Redash to allow any user from a specified domain to log-in. An account will automatically be created for them if one does not already exist.
+
+{% endcallout %}
+
+5. Visit **Settings > General**. Complete the _Allowed User Domains_ box with the domains that should be able to log-in to your Redash instance.
+
 # SAML 2.0
 
 Redash can authenticate users with any IDP that supports the SAML 2.0 protocol thanks to the `pysaml` library.


### PR DESCRIPTION
Adding instructions for using Azure AD Oauth for account login in Redash (Microsoft work or school account).

See the associated code change PR here: https://github.com/getredash/redash/pull/5795