### PR TITLE
Fix an invalid sample JSON message in api.md

### DIFF
--- a/src/pages/kb/user-guide/integrations-and-api/api.md
+++ b/src/pages/kb/user-guide/integrations-and-api/api.md
@@ -74,17 +74,16 @@ a `parameters` object.
 Here's an example JSON object including different parameter types:
 
 ```
-{ 
-    "parameters": {
-    	"number_param": 100,
-    	"date_param": "2020-01-01",
-    	"date_range_param": {
-    		"start": "2020-01-01",
-    		"end": "2020-12-31"
-    		}
-    	},
-      "max_age": 1800
+{
+  "parameters": {
+    "number_param": 100,
+    "date_param": "2020-01-01",
+    "date_range_param": {
+      "start": "2020-01-01",
+      "end": "2020-12-31"
     }
+  },
+  "max_age": 1800
 }
 ```
 


### PR DESCRIPTION
- This PR fixes an invalid sample JSON message in `POST /api/queries/<id>/results` documentation.