### PR TITLE
Remove 'Blog' from the global footer nav

### DIFF
--- a/src/data/footer_links.yml
+++ b/src/data/footer_links.yml
@@ -12,8 +12,6 @@
   links:
     - name: About
       url: /community/
-    - name: Blog
-      url: https://blog.redash.io/
 - name: Help
   links:
     - name: Knowledge Base


### PR DESCRIPTION
This patch removes deprecated 'Blog' link from the global footer navigation.
This PR is related to discussion https://github.com/getredash/redash/discussions/6849.

## Test Environment
- GitHub Codespaces
- Build and Deploy with Docker (As described in your [README.md](https://github.com/getredash/website#docker-setup))