### PR TITLE
Responding to 'docker compose' filename changes

### DIFF
--- a/src/pages/kb/open-source/admin-guide/how-to-upgrade.md
+++ b/src/pages/kb/open-source/admin-guide/how-to-upgrade.md
@@ -40,7 +40,7 @@ If you are currently running an instance of Redash prior to V7, **do not upgrade
 
 1. Make sure to backup your data. You need to backup Redash's PostgreSQL database (the database Redash stores metadata in, not the ones you might be querying) and your `.env` file (if it exists). The data in Redis is transient.
 2. Change directory to `/opt/redash`.
-3. Update `/opt/redash/docker-compose.yml` Redash image reference to the one you want to upgrade to.
+3. Update `/opt/redash/compose.yaml` Redash image reference to the one you want to upgrade to.
 4. Stop Redash services: `docker compose stop server scheduler scheduled_worker adhoc_worker` (you might need to list additional services if you updated your configuration)
 5. Apply migration (if necessary): `docker compose run --rm server manage db upgrade`
 6. Start services: `docker compose up -d`

--- a/src/pages/kb/open-source/admin-guide/secrets.md
+++ b/src/pages/kb/open-source/admin-guide/secrets.md
@@ -53,7 +53,7 @@ QinPGTd7Ulec03lar0vkI9ojqmXsuw4VOyirnC5NuvEdJSCwLwesmknNygXITunT
 ```
 
 {% callout info %}
-The official Redash cloud images found [here]({% link _kb/open-source/setup.md %}) generate unique secret keys automatically during deployment. If you deployed Redash manually with Docker Compose you can create a `.env` file adjacent to `docker-compose.yml` and set your environment variables there.
+The official Redash cloud images found [here]({% link _kb/open-source/setup.md %}) generate unique secret keys automatically during deployment. If you deployed Redash manually with Docker Compose you can create a `.env` file adjacent to `compose.yaml` and set your environment variables there.
 {% endcallout %}
 
 ## Changing a Secret Keys

--- a/src/pages/kb/open-source/setup.md
+++ b/src/pages/kb/open-source/setup.md
@@ -87,7 +87,7 @@ The AWS, DigitalOcean and Google Compute Engine images are created using our [Se
 What the script does is:
 
 1. Install Docker and Docker Compose.
-2. Download our recommended [Docker Compose configuration](https://github.com/getredash/setup/blob/master/data/docker-compose.yml) and create initial configuration.
+2. Download our recommended [Docker Compose configuration](https://github.com/getredash/setup/blob/master/data/compose.yaml) and create initial configuration.
 3. Start everything.
 
 Note that the script assumes you are running it on a "clean" machine. If you’re running this script on a machine that is used for other purposes, you might want to tweak it to your needs.
@@ -100,7 +100,7 @@ For every Redash release we also create updated [Docker image](https://hub.docke
 
 If you do not use one of our cloud images, you must manually set up Redash's [secret keys]({% link _kb/open-source/admin-guide/secrets.md %}):
 
-1. Create a `.env` in the same folder as your `docker-compose.yml` file.
+1. Create a `.env` in the same folder as your `compose.yaml` file.
 2. Write any sensitive environment variables in bash syntax:
 
 ```bash
@@ -115,7 +115,7 @@ Do not commit this file to version control.
 
 For development environment setup, please refer to the [developer guide]({% link _kb/open-source/dev-guide.md %}) (which includes Docker specific instructions as well).
 
-To run Redash you need several instances of Redash (API server and background workers to run queries) along with Redis and PostgreSQL. If you don't want or can't use our images or [Setup Script](https://github.com/getredash/setup), you can refer to the [Docker Compose configuration](https://github.com/getredash/setup/blob/master/data/docker-compose.yml) to understand what services you need to define.
+To run Redash you need several instances of Redash (API server and background workers to run queries) along with Redis and PostgreSQL. If you don't want or can't use our images or [Setup Script](https://github.com/getredash/setup), you can refer to the [Docker Compose configuration](https://github.com/getredash/setup/blob/master/data/compose.yaml) to understand what services you need to define.
 
 ## <a name="setup-redash-instance-setup"></a> Setup
 


### PR DESCRIPTION
Fix https://github.com/getredash/setup/issues/66

Resolves an issue where the 'docker-compose.yml' filename was changed to `compose.yaml`
in the `redash`, `setup` repo, but the documentation was not changed.