### PR TITLE
Reconfigure Restyled

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -65,5 +65,5 @@ restylers:
     command:
       - prettier-with-tailwindcss
       - '--write'
-    inlcude:
+    include:
       - pages/**/*.md

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,0 +1,69 @@
+enabled: true
+
+auto: false
+
+# Open Restyle PRs?
+pull_requests: true
+
+# Leave comments on the original PR linking to the Restyle PR?
+comments: true
+
+# Set commit statuses on the original PR?
+statuses:
+  # Red status in the case of differences found
+  differences: true
+  # Green status in the case of no differences found
+  no_differences: true
+  # Red status if we encounter errors restyling
+  error: true
+
+# Request review on the Restyle PR?
+#
+# Possible values:
+#
+#   author: From the author of the original PR
+#   owner: From the owner of the repository
+#   none: Don't
+#
+# One value will apply to both origin and forked PRs, but you can also specify
+# separate values.
+#
+#   request_review:
+#     origin: author
+#     forked: owner
+#
+request_review: author
+
+# Add labels to any created Restyle PRs
+#
+# These can be used to tell other automation to avoid our PRs.
+#
+labels:
+  - restyled
+  - 'Skip CI'
+
+# Labels to ignore
+#
+# PRs with any of these labels will be ignored by Restyled.
+#
+# ignore_labels:
+#   - restyled-ignore
+
+# Restylers to run, and how
+restylers:
+  - name: prettier
+    image: 'restyled/restyler-prettier:v3.3.2-2'
+    command:
+      - prettier-with-tailwindcss
+      - '--write'
+    include:
+      - src/**/*.js
+      - src/**/*.jsx
+      - pages/**/*.jsx
+  - name: prettier-markdown
+    image: 'restyled/restyler-prettier:v3.3.2-2'
+    command:
+      - prettier-with-tailwindcss
+      - '--write'
+    inlcude:
+      - pages/**/*.md

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -54,7 +54,7 @@ restylers:
   - name: prettier
     image: 'restyled/restyler-prettier:v3.3.2-2'
     command:
-      - prettier-with-tailwindcss
+      - prettier
       - '--write'
     include:
       - src/**/*.js
@@ -63,7 +63,7 @@ restylers:
   - name: prettier-markdown
     image: 'restyled/restyler-prettier:v3.3.2-2'
     command:
-      - prettier-with-tailwindcss
+      - prettier
       - '--write'
     include:
       - pages/**/*.md


### PR DESCRIPTION
This PR reconfigures Restyled, which was currently used as a linter.
For consistency with the original repo, I have referenced the configruation files from the original repo: https://github.com/getredash/redash/blob/master/.restyled.yaml

Feel free to leave any comments or reviews. Thank you.