### PR TITLE
Add Content-Security-Policy header to allow all frame ancestors

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,6 +5,17 @@ const config = {
     siteUrl: 'https://redash.io/',
   },
   pathPrefix: '/',
+  headers: [
+    {
+      source: '*',
+      headers: [
+        {
+          key: 'Content-Security-Policy',
+          value: 'frame-ancestors *;',
+        },
+      ],
+    },
+  ],
   plugins: [
     {
       resolve: 'gatsby-source-filesystem',


### PR DESCRIPTION
Fix #710 

Add Content-Security-Policy header to allow all frame ancestors. and 'X-Frame-Options' retains 'DENY'.
Options other than 'DENY' are unavailable because there is only 'SAMEORIGIN'. 'ALLOW-FROM origin' option is obsolete.
You can test this PR by following link: https://dapper-tapioca-6fa259.netlify.app/

Any comments or review are welcome. Thank you.

> Related: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options