### PR TITLE
Use HTTPS settings from the Mozilla SSL Config Generator

### DIFF
--- a/src/pages/kb/open-source/admin-guide/https-ssl-setup.md
+++ b/src/pages/kb/open-source/admin-guide/https-ssl-setup.md
@@ -47,12 +47,10 @@ server {
   ssl_certificate /path-to/cert.pem; # or crt
   ssl_certificate_key /path-to/cert.key;
 
-  # Specifies that we don't want to use SSLv2 (insecure) or SSLv3 (exploitable)
+  # As per the Mozilla SSL Configuration Generator (https://ssl-config.mozilla.org), using the Intermediate setting.
   ssl_protocols TLSv1.2 TLSv1.3;
-  # Uses the server's ciphers rather than the client's
-  ssl_prefer_server_ciphers on;
-  # Specifies which ciphers are okay and which are not okay. List taken from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
-  ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:ECDHE-RSA-AES128-GCM-SHA256:AES256+EECDH:DHE-RSA-AES128-GCM-SHA256:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
+  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+  ssl_prefer_server_ciphers off;
 
   access_log /var/log/nginx/redash.access.log;
 


### PR DESCRIPTION
This is a follow up PR from #641, improving the cipher list and related settings.

The updated settings are from the [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org).