### PR TITLE
Migrate Restyled to GitHub Actions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,0 +1,36 @@
+name: Restyled
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  restyled:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - uses: restyled-io/actions/setup@v4
+      - id: restyler
+        uses: restyled-io/actions/run@v4
+        with:
+          fail-on-differences: true
+
+      - if: |
+          !cancelled() &&
+          steps.restyler.outputs.success == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository          
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: ${{ steps.restyler.outputs.restyled-base }}
+          branch: ${{ steps.restyler.outputs.restyled-head }}
+          title: ${{ steps.restyler.outputs.restyled-title }}
+          body: ${{ steps.restyler.outputs.restyled-body }}
+          labels: "restyled"
+          reviewers: ${{ github.event.pull_request.user.login }}
+          delete-branch: true


### PR DESCRIPTION
It looks like Restyled, which we're using as a linter, recently migrated to GitHub Actions from GitHub Apps.
So with this PR, we are also migrate to GitHub Actions. Related: https://docs.restyled.io/news/github-actions-pivot/

This change has also been tested in fork.
Commit that add this workflow (actual change to current PR): https://github.com/lucydodo/website/commit/191b27d17661a68349dc0bfe5801683beaccf83f
Induction PR: https://github.com/lucydodo/website/pull/1
Generated PR: https://github.com/lucydodo/website/pull/2

Any comments or review are welcome. Thank you.