### PR TITLE
fix algolia search by using promise instead of callback

### DIFF
--- a/src/pages/help/index.jsx
+++ b/src/pages/help/index.jsx
@@ -26,7 +26,7 @@ class HelpPage extends React.Component {
 
   search(e) {
     this.setState({ searchQuery: e.target.value }, () => {
-      index.search(this.state.searchQuery, (err, content) => {
+      index.search(this.state.searchQuery).then((content) => {
         if (content && content.query === this.state.searchQuery) {
           this.setState({
             hits: content.hits,


### PR DESCRIPTION
# WHY

https://github.com/getredash/website/issues/837

On Redash official site knowledge base( [redash ](https://redash.io/help/) ), knowledge base search does not work.



# HOW

Following the Algolia search API, use promise instead of callback.

# References

- Algolia Search Index API: https://www.algolia.com/doc/api-reference/api-methods/search/

# Test
Manually tested as below.

Before fixing:
<img width="1366" height="908" alt="image" src="https://github.com/user-attachments/assets/f346aa40-be1f-4944-8de3-a1527cd75617" />


After fixing:
<img width="1366" height="908" alt="image" src="https://github.com/user-attachments/assets/21a02e96-1e6e-4c1f-a401-af87820ea353" />

